### PR TITLE
TST: start `test-socket-server` within the fixture

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,17 +39,17 @@ jobs:
           pip install -r requirements-dev.txt
           pip list
 
-      - name: Start test socket server
-        run: |
-          set -vxeuo pipefail
-          nohup test-socket-server > /tmp/socket.log 2>&1 &
+      # - name: Start test socket server
+      #   run: |
+      #     set -vxeuo pipefail
+      #     nohup test-socket-server > /tmp/socket.log 2>&1 &
 
       - name: Test with pytest
         run: |
           set -vxeuo pipefail
           pytest -s -vv
 
-      - name: Check socket server logs
-        run: |
-          set -vxeuo pipefail
-          cat /tmp/socket.log
+      # - name: Check socket server logs
+      #   run: |
+      #     set -vxeuo pipefail
+      #     cat /tmp/socket.log

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
   - repo: https://github.com/ambv/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
@@ -16,7 +16,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.2
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/kynan/nbstripout

--- a/atfdb/atfdb.py
+++ b/atfdb/atfdb.py
@@ -321,6 +321,7 @@ def host_connect(host_name=None, port_number=None):
 
     timestamp()
     print(f"{ATF_DB_SUCCESS}Successful connection to database host.")
+    return atf_db_socket
 
 
 def host_disconnect():

--- a/atfdb/tests/conftest.py
+++ b/atfdb/tests/conftest.py
@@ -1,3 +1,6 @@
+import subprocess
+import time as ttime
+
 import pytest
 
 from atfdb.atfdb import host_connect, host_disconnect
@@ -20,8 +23,26 @@ SERVER_PORT = 5000
 
 @pytest.fixture(scope="session")
 def socket_server():
+    p = subprocess.Popen(
+        "test-socket-server".split(),
+        start_new_session=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        shell=True,
+    )
+    ttime.sleep(2.0)
+
+    # Connect to the test socket server with the client
     host_connect(SERVER_ADDRESS, SERVER_PORT)
 
     yield
 
+    # Disconnect the client from the test socket server
     host_disconnect()
+
+    # Print logs
+    # print(f"{logfile[-1] = }")
+    std_out, std_err = p.communicate()
+    std_out = std_out.decode()
+    print(std_out)
+    p.terminate()

--- a/atfdb/tests/socket_server.py
+++ b/atfdb/tests/socket_server.py
@@ -23,11 +23,12 @@ def server_program(seed=0):
     server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     # look closely. The bind() function takes tuple as argument
     server_socket.bind((host, port))  # bind host address and port together
+    print_log(f"Started test socket server at {host}:{port}")
 
     # configure how many client the server can listen simultaneously
     server_socket.listen(2)
     conn, address = server_socket.accept()  # accept new connection
-    print_log("Connection from: " + str(address))
+    print_log(f"Connection from: {address}")
     data = "greeting"
     conn.send(data.encode())  # send data to the client
 
@@ -55,6 +56,7 @@ def server_program(seed=0):
             conn.send(reply.encode())  # send data to the client
         else:
             print_log(f"{data = }")
+    print_log("Closing connection...")
     conn.close()  # close the connection
 
 


### PR DESCRIPTION
This PR adds the `test-socket-server` startup step as a part of the fixture used in the tests (with the `session` scope). This makes sure we have a running server before the client attempts to connect to it.